### PR TITLE
Update INFINITI QX70 generations: Added Wikipedia reference and standardized README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# INFINITI QX70
 
+This repository contains signal set configurations for the INFINITI QX70, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the INFINITI QX70.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Infiniti_QX70"
+
 generations:
   - name: "First Generation (as INFINITI FX)"
     start_year: 2003


### PR DESCRIPTION
- Cross-referenced with Wikipedia article confirming two generations (2003-2008, 2009-2017)
- Added references array with Infiniti QX70 Wikipedia URL
- Updated README.md with standard template for vehicle documentation
